### PR TITLE
Resolve/Reject the client promise when the connection is made.

### DIFF
--- a/redis.js
+++ b/redis.js
@@ -41,11 +41,14 @@ var PooledRedis = function PooledRedis(port, host, options) {
       var client = Redis.createClient(self.port, self.host, self.options);
       client.on('error', function (err) {
         console.log('Redis Error', err);
+        callback(err, null);
+      });
+      client.on('connect', function() {
+        callback(null, client);
       });
       client.release = function() {
         self.pool.release(client);
       };
-      callback(null, client);
     },
     destroy: function(client) {
       client.end();


### PR DESCRIPTION
I noticed while running the unit tests that if Redis isn't available, the tests print an error message but continue on. This leads me to believe that in the event Redis isn't available in production, we'll start processing work and fail mid-way through when we try to issue a Redis command.

It seems like the `redis.client` method (which is called to by `command` to acquire a client from the pool) should `reject` the Promise if the connection can not be made. As a corollary, the Promise should not be resolved until the connection is actually ready.
