### PR TITLE
client.end() with no argument is deprecated

### DIFF
--- a/redis.js
+++ b/redis.js
@@ -69,7 +69,7 @@ var PooledRedis = function PooledRedis(port, host, options) {
       };
     },
     destroy: function(client) {
-      client.end();
+      client.quit();
     },
     max: self.options.poolMaxSize,
     min: self.options.poolMinSize,


### PR DESCRIPTION
This will get rid of messages like this:

> node_redis: Using .end() without the flush parameter is deprecated and throws from v.3.0.0 on.

see documentation at https://github.com/NodeRedis/node_redis#clientquit

@v-yarotsky @sanjayprabhu 