### PR TITLE
Add hmget to pooled redis

### DIFF
--- a/redis.js
+++ b/redis.js
@@ -119,6 +119,11 @@ PooledRedis.prototype.hgetall = function(key) {
   return this.command('hgetall', key);
 };
 
+PooledRedis.prototype.hmget = function() {
+  var args = ['hmget'].concat(Array.prototype.slice.call(arguments));
+  return this.command.apply(this.args);
+}
+
 PooledRedis.prototype.hmset = function(key, updates) {
   var args = ['hmset', key].concat(_.flatten(_.pairs(updates)));
 


### PR DESCRIPTION
Adds hmget to pooled redis. The node library allows you to pass a key and a variable number of fields (e.g. `hmget(key, f1, f2, f3)`), or a key and an array of fields (e.g. `hmget(key, [f1, f2, f3])`).

This form of the function just passes all the arguments given to it through to the redis library, so it supports both forms of the hmget call.